### PR TITLE
feat: define SEO meta and `ogImage` for each page

### DIFF
--- a/portfolio/pages/index.vue
+++ b/portfolio/pages/index.vue
@@ -5,3 +5,16 @@
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+useSeoMeta({
+  title: "Home • lloyd.cx",
+  ogTitle: "Home",
+  description:
+    "Specialising in full-stack, cloud-native web applications and real-time data streaming.",
+  ogDescription:
+    "Specialising in full-stack, cloud-native web applications and real-time data streaming.",
+  ogImage: "/images/lloyd.jpg",
+  twitterCard: "summary_large_image",
+});
+</script>

--- a/portfolio/pages/index.vue
+++ b/portfolio/pages/index.vue
@@ -14,7 +14,7 @@ useSeoMeta({
     "Specialising in full-stack, cloud-native web applications and real-time data streaming.",
   ogDescription:
     "Specialising in full-stack, cloud-native web applications and real-time data streaming.",
-  ogImage: "/images/lloyd.jpg",
+  ogImage: "https://lloyd.cx/images/lloyd.jpg",
   twitterCard: "summary_large_image",
 });
 </script>

--- a/portfolio/pages/portfolio.vue
+++ b/portfolio/pages/portfolio.vue
@@ -12,7 +12,7 @@ useSeoMeta({
   ogTitle: "Portfolio",
   description: "Software Engineer II, Production Platforms at Deliveroo",
   ogDescription: "Software Engineer II, Production Platforms at Deliveroo",
-  ogImage: "/images/lloyd.jpg",
+  ogImage: "https://lloyd.cx/images/lloyd.jpg",
   twitterCard: "summary_large_image",
 });
 </script>

--- a/portfolio/pages/portfolio.vue
+++ b/portfolio/pages/portfolio.vue
@@ -5,3 +5,14 @@
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+useSeoMeta({
+  title: "Portfolio • lloyd.cx",
+  ogTitle: "Portfolio",
+  description: "Software Engineer II, Production Platforms at Deliveroo",
+  ogDescription: "Software Engineer II, Production Platforms at Deliveroo",
+  ogImage: "/images/lloyd.jpg",
+  twitterCard: "summary_large_image",
+});
+</script>

--- a/portfolio/pages/travel/index.vue
+++ b/portfolio/pages/travel/index.vue
@@ -21,7 +21,7 @@ useSeoMeta({
   ogTitle: "Travel",
   description: "All of my trips and travels.",
   ogDescription: "All of my trips and travels.",
-  ogImage: "/images/lloyd.jpg",
+  ogImage: "https://lloyd.cx/images/lloyd.jpg",
   twitterCard: "summary_large_image",
 });
 </script>

--- a/portfolio/pages/travel/index.vue
+++ b/portfolio/pages/travel/index.vue
@@ -15,4 +15,13 @@ const route = useRoute();
 const { data: travelCardGrid } = await useAsyncData(route.path, () => {
   return queryCollection("trips").order("startDate", "DESC").all();
 });
+
+useSeoMeta({
+  title: "Travel • lloyd.cx",
+  ogTitle: "Travel",
+  description: "All of my trips and travels.",
+  ogDescription: "All of my trips and travels.",
+  ogImage: "/images/lloyd.jpg",
+  twitterCard: "summary_large_image",
+});
 </script>

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -129,7 +129,7 @@ useSeoMeta({
     trip?.value?.title + " (" + formatEndDate(trip?.value?.startDate) + ")",
   description: trip?.value?.description,
   ogDescription: trip?.value?.description,
-  ogImage: trip?.value?.coverPhoto,
+  ogImage: "https://lloyd.cx/" + trip?.value?.coverPhoto,
   twitterCard: "summary_large_image",
 });
 </script>

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -118,4 +118,18 @@ const getFlagEmoji = (countryCode: string) => {
     .map((char) => String.fromCodePoint(OFFSET + char.charCodeAt(0)))
     .join("");
 };
+
+useSeoMeta({
+  title:
+    trip?.value?.title +
+    " (" +
+    formatEndDate(trip?.value?.startDate) +
+    ") • lloyd.cx",
+  ogTitle:
+    trip?.value?.title + " (" + formatEndDate(trip?.value?.startDate) + ")",
+  description: trip?.value?.description,
+  ogDescription: trip?.value?.description,
+  ogImage: trip?.value?.coverPhoto,
+  twitterCard: "summary_large_image",
+});
 </script>


### PR DESCRIPTION
This pull request:
- Defines SEO meta for each page
- Includes a fully-qualified `ogImage` for each page

<img width="412" height="336" alt="image" src="https://github.com/user-attachments/assets/86f467f1-3930-4dbe-b78b-d745f1bacafd" />
