### PR TITLE
feat: refresh trip page albums, lightbox and styling

### DIFF
--- a/portfolio/content/trips/2024-05-levant/index.json
+++ b/portfolio/content/trips/2024-05-levant/index.json
@@ -16,9 +16,9 @@
       "slug": "po_019b6fc3-fb56-7795-bab2-6fc869fb7176",
       "title": "Israel, Part 1",
       "description": "Arrival in Tel Aviv, and a trip to Masada, Ein Gedi, and the Dead Sea.",
-      "datePosted": "2024-05-21",
+      "datePosted": "2024-05-14",
       "startDate": "2024-05-11",
-      "endDate": "2024-05-21",
+      "endDate": "2024-05-14",
       "photos": [
         {
           "slug": "img-3463",
@@ -277,9 +277,9 @@
       "slug": "po_019b6fc3-fb56-7795-bab2-6fc869fb7176",
       "title": "Israel, Part 2",
       "description": "Jerusalem and the Golan Heights.",
-      "datePosted": "2024-05-20",
+      "datePosted": "2024-05-21",
       "startDate": "2024-05-20",
-      "endDate": "2024-05-20",
+      "endDate": "2024-05-21",
       "photos": [
         {
           "slug": "img-4128",

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -1,197 +1,160 @@
 <template>
-  <div class="container mx-auto max-w-6xl sm:py-5">
-    <div class="text-slate-50">
-      <header
-        class="relative h-64 bg-cover bg-center"
-        :style="'background-image: url(&quot;' + trip?.coverPhoto + '&quot;);'"
+  <div class="min-h-screen text-slate-50">
+    <div class="mx-auto max-w-lg space-y-4 px-0 py-4 sm:px-4">
+      <section
+        class="relative mx-4 overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-[0_12px_40px_rgba(0,0,0,0.35)] backdrop-blur-xl sm:mx-0"
       >
-        <div class="absolute inset-0 bg-black/50"></div>
+        <NuxtImg
+          v-if="trip?.coverPhoto"
+          :src="trip.coverPhoto"
+          :alt="trip?.title"
+          class="absolute inset-0 h-full w-full object-cover opacity-40"
+          height="600"
+          width="1200"
+        />
         <div
-          class="relative mx-auto flex h-full items-center justify-between px-5"
-        >
-          <div>
-            <h1 class="text-4xl font-bold">{{ trip?.title }}</h1>
-            <div class="mt-2 flex space-x-1 text-sm">
-              <span
-                class="rounded-full border border-white/10 bg-white/5 px-2 py-1 backdrop-blur-[10px]"
-              >
-                {{ formatStartDate(trip?.startDate) }} -
-                {{ formatEndDate(trip?.endDate) }}
-              </span>
-              <span
-                class="flex items-center space-x-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-sm drop-shadow-sm backdrop-blur-[10px]"
-              >
-                <Twemoji
-                  v-for="(emoji, i) in trip?.countries.map(getFlagEmoji)"
-                  :key="i"
-                  :emoji="emoji"
-                />
-              </span>
-            </div>
+          class="absolute inset-0 bg-gradient-to-br from-black/40 via-black/30 to-black/70"
+        />
+
+        <div class="relative p-4 sm:p-5">
+          <div class="flex flex-wrap items-center gap-1.5 text-xs">
+            <span
+              class="rounded-full border border-white/10 bg-white/10 px-2 py-1 text-white/80 backdrop-blur-xl"
+            >
+              {{ formatDateRange(trip?.startDate, trip?.endDate) }}
+            </span>
+            <span
+              class="flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-2 py-1 text-white/80 backdrop-blur-xl"
+            >
+              <Twemoji
+                v-for="(emoji, i) in trip?.countries.map(getFlagEmoji)"
+                :key="i"
+                :emoji="emoji"
+              />
+            </span>
           </div>
+
+          <h1 class="mt-2 text-3xl font-semibold tracking-tight text-white">
+            {{ trip?.title }}
+          </h1>
+          <p class="mt-1.5 max-w-prose text-sm text-white/70">
+            {{ trip?.description }}
+          </p>
         </div>
-      </header>
+      </section>
 
-      <main class="mx-auto -mt-16 max-w-6xl pb-12">
-        <div class="px-5">
-          <!-- Trip summary -->
-          <section
-            class="relative mb-10 overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.35)] backdrop-blur-xl"
-          >
-            <!-- subtle glow -->
+      <section class="space-y-4">
+        <div
+          v-if="!trip?.posts?.length"
+          class="rounded-2xl border border-white/10 bg-white/5 p-4 text-white/70 backdrop-blur-xl"
+        >
+          No posts yet.
+        </div>
+
+        <article
+          v-for="post in trip.posts"
+          v-else
+          :key="post.slug"
+          class="overflow-hidden border border-white/10 bg-white/5 shadow-none backdrop-blur-xl sm:rounded-2xl sm:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
+        >
+          <header class="flex items-center gap-2 p-3">
             <div
-              class="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-transparent"
-              aria-hidden="true"
-            />
+              class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/10"
+            >
+              <NuxtImg
+                src="/trips/2025-04-asia/photos/IMG_2292.jpeg"
+                :alt="post?.title"
+                class="h-full w-full object-cover"
+                height="80"
+                width="80"
+              />
+            </div>
 
-            <div class="relative">
-              <p class="text-base leading-relaxed text-white/90">
-                {{ trip?.description }}
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm font-semibold text-white">
+                {{ post?.title }}
               </p>
+              <p class="truncate text-xs text-white/60">
+                {{ formatPostDate(post?.datePosted) }}
+              </p>
+            </div>
 
-              <!-- Tags -->
+            <div
+              class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-xs text-white/70"
+            >
+              {{ post?.photos?.length ?? 0 }} photos
+            </div>
+          </header>
+
+          <div class="relative">
+            <div
+              data-carousel="true"
+              class="carousel-scrollbar relative z-0 flex cursor-grab select-none gap-1.5 overflow-x-scroll bg-white/5 px-2 py-2 active:cursor-grabbing"
+            >
               <div
-                v-if="trip?.tags?.length"
-                class="mt-5 flex flex-wrap gap-2"
-                aria-label="Trip tags"
+                v-for="photo in post?.photos"
+                :key="photo.slug"
+                class="relative aspect-[4/5] w-[28.5%] shrink-0 overflow-hidden rounded-lg sm:w-40 md:w-44 lg:w-48"
               >
-                <span
-                  v-for="(tag, i) in trip.tags"
-                  :key="`${tag}-${i}`"
-                  class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-sm text-white/80 backdrop-blur-xl transition hover:bg-white/10"
+                <button
+                  type="button"
+                  class="block h-full w-full"
+                  @click="onPhotoClick(photo, $event)"
                 >
-                  #{{ tag }}
-                </span>
-              </div>
-
-              <!-- Stats -->
-              <div class="mt-7 flex flex-wrap gap-6">
-                <div
-                  class="min-w-[120px] rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-center backdrop-blur-xl"
-                >
-                  <div class="text-3xl font-semibold tracking-tight text-white">
-                    {{ trip?.posts?.length ?? 0 }}
-                  </div>
-                  <div
-                    class="mt-0.5 text-xs uppercase tracking-wider text-white/60"
-                  >
-                    Posts
-                  </div>
-                </div>
-                <!-- Add more stat blocks later if you want (photos, likes, etc.) -->
+                  <NuxtImg
+                    :src="photo.photoUrl"
+                    :alt="photo.title"
+                    class="h-full w-full object-cover"
+                    height="400"
+                    width="400"
+                  />
+                </button>
               </div>
             </div>
-          </section>
-        </div>
 
-        <!-- Posts -->
-        <section class="mt-8">
-          <div class="mb-3 flex items-end justify-between px-5">
-            <h2 class="text-2xl font-semibold tracking-tight text-white">
-              Posts
-            </h2>
+            <div
+              class="pointer-events-none absolute bottom-3 right-0 top-0 z-10 w-6 bg-gradient-to-l from-slate-950/80 via-slate-950/40 to-transparent transition-opacity"
+            />
           </div>
 
           <div
-            v-if="!trip.posts?.length"
-            class="mx-1 rounded-2xl border border-white/10 bg-white/5 p-6 text-white/70 backdrop-blur-xl"
+            v-if="post?.description"
+            class="border-t border-white/10 px-3 py-2 text-sm text-white/65"
           >
-            No posts yet.
+            {{ post.description }}
           </div>
-
-          <!-- List -->
-          <div v-else class="space-y-8 sm:px-5">
-            <details
-              v-for="post in trip.posts"
-              :key="post.slug"
-              class="hover:bg-white/7 group overflow-hidden border border-white/10 bg-white/5 shadow-[0_10px_30px_rgba(0,0,0,0.30)] backdrop-blur-xl transition hover:border-white/20 sm:rounded-2xl"
-            >
-              <summary
-                class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden"
-              >
-                <!-- Header -->
-                <div class="px-5 py-5">
-                  <div class="flex items-start justify-between gap-4">
-                    <div class="min-w-0">
-                      <h3
-                        class="truncate text-xl font-semibold tracking-tight text-white"
-                      >
-                        {{ post?.title }}
-                      </h3>
-                      <p class="mt-1 text-sm leading-relaxed text-white/70">
-                        {{ post?.description }}
-                      </p>
-                    </div>
-
-                    <div class="flex shrink-0 items-center gap-3">
-                      <div
-                        class="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-center text-xs text-white/70 backdrop-blur-xl"
-                      >
-                        <div class="text-base font-semibold text-white">
-                          {{ post?.photos?.length ?? 0 }}
-                        </div>
-                        photos
-                      </div>
-
-                      <svg
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        class="h-5 w-5 text-white/70 transition-transform duration-200 group-open:rotate-180"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="border-t border-white/10" />
-
-                <!-- PREVIEW ROW (visible when closed) -->
-                <div class="relative group-open:hidden">
-                  <div class="max-h-32 overflow-hidden">
-                    <div class="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-                      <PhotoCard
-                        v-for="photo in post.photos"
-                        :key="photo.slug"
-                        v-bind="photo"
-                        class="transition group-hover:opacity-95"
-                      />
-                    </div>
-                  </div>
-
-                  <div
-                    class="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-black/60 to-transparent"
-                    aria-hidden="true"
-                  />
-                </div>
-              </summary>
-
-              <!-- FULL CONTENT (only visible when open) -->
-              <div class="hidden border-white/10 group-open:block">
-                <div class="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-                  <PhotoCard
-                    v-for="photo in post.photos"
-                    :key="photo.slug"
-                    v-bind="photo"
-                    class="transition group-hover:opacity-95"
-                  />
-                </div>
-              </div>
-            </details>
-          </div>
-        </section>
-      </main>
+        </article>
+      </section>
     </div>
+
+    <Teleport to="body">
+      <div
+        v-if="lightboxPhoto"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+        @click.self="closeLightbox"
+      >
+        <div class="relative max-h-[90vh] max-w-[90vw]">
+          <NuxtImg
+            :src="lightboxPhoto.photoUrl"
+            :alt="lightboxPhoto.title"
+            class="h-auto max-h-[90vh] w-auto max-w-[90vw] rounded-2xl object-contain"
+            loading="eager"
+          />
+        </div>
+        <button
+          type="button"
+          class="fixed right-4 top-4 z-10 rounded-full border border-white/20 bg-black/60 px-3 py-1 text-sm text-white/80 transition hover:text-white"
+          @click="closeLightbox"
+        >
+          Close
+        </button>
+      </div>
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
-import PhotoCard from "~/components/PhotoCard.vue";
+import { onBeforeUnmount, onMounted, ref } from "vue";
 
 const route = useRoute();
 
@@ -202,27 +165,55 @@ const { data: trip } = await useAsyncData(route.path, () => {
     .first();
 });
 
-const formatStartDate = (date: string | undefined) => {
+const formatDate = (date: string | undefined, withYear = true) => {
+  if (!date) {
+    return "-";
+  }
   const options: Intl.DateTimeFormatOptions = {
     day: "numeric",
     month: "short",
+    year: withYear ? "numeric" : undefined,
   };
-  if (date) {
-    return new Date(date).toLocaleDateString("en", options);
-  }
-  return "-";
+  return new Date(date).toLocaleDateString("en-US", options);
 };
 
-const formatEndDate = (date: string | undefined) => {
-  const options: Intl.DateTimeFormatOptions = {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  };
-  if (date) {
-    return new Date(date).toLocaleDateString("en", options);
+const formatDateRange = (start?: string, end?: string) => {
+  if (!start && !end) {
+    return "-";
   }
-  return "-";
+  if (start && !end) {
+    return formatDate(start, true);
+  }
+  if (!start && end) {
+    return formatDate(end, true);
+  }
+
+  const startDate = new Date(start as string);
+  const endDate = new Date(end as string);
+
+  const sameYear = startDate.getFullYear() === endDate.getFullYear();
+  const sameMonth = sameYear && startDate.getMonth() === endDate.getMonth();
+
+  if (sameMonth) {
+    const month = startDate.toLocaleDateString("en-US", { month: "short" });
+    const year = startDate.getFullYear();
+    return `${month} ${startDate.getDate()}–${endDate.getDate()}, ${year}`;
+  }
+
+  if (sameYear) {
+    const startLabel = formatDate(start, false);
+    const endLabel = formatDate(end, false);
+    return `${startLabel}–${endLabel}, ${startDate.getFullYear()}`;
+  }
+
+  return `${formatDate(start, true)}–${formatDate(end, true)}`;
+};
+
+const formatPostDate = (date: string | undefined) => {
+  if (!date) {
+    return "-";
+  }
+  return formatDate(date, true);
 };
 
 const getFlagEmoji = (countryCode: string) => {
@@ -237,13 +228,63 @@ useSeoMeta({
   title:
     trip?.value?.title +
     " (" +
-    formatEndDate(trip?.value?.startDate) +
-    ") • lloyd.cx",
+    formatDate(trip?.value?.startDate, true) +
+    ") - lloyd.cx",
   ogTitle:
-    trip?.value?.title + " (" + formatEndDate(trip?.value?.startDate) + ")",
+    trip?.value?.title + " (" + formatDate(trip?.value?.startDate, true) + ")",
   description: trip?.value?.description,
   ogDescription: trip?.value?.description,
   ogImage: "https://lloyd.cx/" + trip?.value?.coverPhoto,
   twitterCard: "summary_large_image",
 });
+
+type LightboxPhoto = {
+  photoUrl: string;
+  title?: string;
+};
+
+const lightboxPhoto = ref<LightboxPhoto | null>(null);
+
+const onPhotoClick = (photo: LightboxPhoto) => {
+  lightboxPhoto.value = photo;
+};
+
+const closeLightbox = () => {
+  lightboxPhoto.value = null;
+};
+
+const onKeyDown = (event: KeyboardEvent) => {
+  if (event.key === "Escape") {
+    closeLightbox();
+  }
+};
+
+onMounted(() => {
+  window.addEventListener("keydown", onKeyDown);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onKeyDown);
+});
 </script>
+
+<style scoped>
+.carousel-scrollbar {
+  scrollbar-color: #334155 #0f172a;
+  scrollbar-width: thin;
+}
+
+.carousel-scrollbar::-webkit-scrollbar {
+  height: 8px;
+}
+
+.carousel-scrollbar::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 999px;
+}
+
+.carousel-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(51, 65, 85, 0.9);
+  border-radius: 999px;
+}
+</style>


### PR DESCRIPTION
This pull request:
- Refreshes trip page by replacing accordions with side-scrolling carousels
- Implements lightbox modal to replace direct links to image files
- Tweaks trip page styling, whitespacing and layout

<img width="693" height="852" alt="image" src="https://github.com/user-attachments/assets/8c91b952-ef0f-421b-9abd-af1c2aec2149" />
