### PR TITLE
feat: three column layout, 3:4 aspect ratio, larger images in carousel, and polish

### DIFF
--- a/portfolio/components/NavigationBar.vue
+++ b/portfolio/components/NavigationBar.vue
@@ -8,7 +8,7 @@
             src="/logo/lloyd-cat-3-128.png"
             width="128"
             height="128"
-            alt="Pink boxes logo"
+            alt="Pixel cat logo"
           />
           <span
             class="py-1 text-xl font-semibold text-slate-50 duration-100 hover:text-white"

--- a/portfolio/components/NavigationBar.vue
+++ b/portfolio/components/NavigationBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="container mx-auto flex px-5 py-5 md:px-3">
+  <nav class="container mx-auto flex px-2 py-5 md:px-3">
     <ul class="flex flex-grow space-x-4">
       <li>
         <NuxtLink to="/" class="flex items-center space-x-3">

--- a/portfolio/components/NavigationFooter.vue
+++ b/portfolio/components/NavigationFooter.vue
@@ -1,6 +1,6 @@
 <template>
   <footer
-    class="container mx-auto flex flex-col items-center px-3 py-8 sm:flex-row"
+    class="container mx-auto flex flex-col items-center px-2 md:px-3 py-8 sm:flex-row"
   >
     <ul class="mx-auto mt-5 flex flex-grow">
       <li>

--- a/portfolio/components/NavigationFooter.vue
+++ b/portfolio/components/NavigationFooter.vue
@@ -1,6 +1,6 @@
 <template>
   <footer
-    class="container mx-auto flex flex-col items-center px-2 md:px-3 py-8 sm:flex-row"
+    class="container mx-auto flex flex-col items-center px-2 py-8 sm:flex-row md:px-3"
   >
     <ul class="mx-auto mt-5 flex flex-grow">
       <li>

--- a/portfolio/components/PhotoCard.vue
+++ b/portfolio/components/PhotoCard.vue
@@ -1,15 +1,15 @@
 <template>
   <NuxtLink id="travel-card" :to="photoUrl" external>
     <div
-      class="group relative aspect-[4/5] overflow-hidden border border-white/30 shadow-lg"
+      class="group relative aspect-[3/4] overflow-hidden border border-white/30 shadow-lg"
     >
       <NuxtImg
         :src="photoUrl"
         :alt="title"
         :modifiers="{ rotate: null }"
         class="absolute inset-0 h-full w-full bg-slate-700 object-cover"
-        height="600"
-        width="480"
+        height="400"
+        width="300"
       />
       <div
         class="absolute bottom-0 left-0 z-10 flex w-full flex-col bg-slate-900/50 px-3 py-1"

--- a/portfolio/components/TravelCard.vue
+++ b/portfolio/components/TravelCard.vue
@@ -32,7 +32,7 @@
         <div class="flex items-center space-x-2">
           <div class="flex w-full items-center justify-between">
             <h3
-              class="text-xs font-semibold text-slate-50 drop-shadow-sm md:text-base truncate"
+              class="truncate text-xs font-semibold text-slate-50 drop-shadow-sm md:text-base"
             >
               {{ title }}
             </h3>

--- a/portfolio/components/TravelCard.vue
+++ b/portfolio/components/TravelCard.vue
@@ -32,7 +32,7 @@
         <div class="flex items-center space-x-2">
           <div class="flex w-full items-center justify-between">
             <h3
-              class="text-sm font-semibold text-slate-50 drop-shadow-sm md:text-base"
+              class="text-xs font-semibold text-slate-50 drop-shadow-sm md:text-base truncate"
             >
               {{ title }}
             </h3>

--- a/portfolio/components/TravelCard.vue
+++ b/portfolio/components/TravelCard.vue
@@ -73,7 +73,7 @@ const props = defineProps<TravelCardProps>();
 
 const formatDate = (date: string) => {
   const options: Intl.DateTimeFormatOptions = {
-    month: "long",
+    month: "short",
     year: "numeric",
   };
   return new Date(date).toLocaleDateString("en", options);

--- a/portfolio/components/TravelCard.vue
+++ b/portfolio/components/TravelCard.vue
@@ -1,14 +1,14 @@
 <template>
   <NuxtLink id="travel-card" :to="`/travel/trips/${slug}/`">
     <div
-      class="group relative aspect-[4/5] overflow-hidden rounded-2xl border border-slate-50/30 shadow-lg"
+      class="group relative aspect-[3/4] overflow-hidden rounded-2xl border border-slate-50/10 shadow-lg"
     >
       <NuxtImg
         :src="coverPhoto"
         :alt="title"
         class="absolute inset-0 h-full w-full object-cover"
-        height="500"
-        width="400"
+        height="400"
+        width="300"
       />
       <div
         class="pointer-events-none absolute inset-0 z-0 rounded-2xl bg-slate-900/10 opacity-0 transition duration-100 group-hover:opacity-100 group-hover:shadow-[0_0_25px_4px_rgba(255,255,255,0.6)]"

--- a/portfolio/components/TravelCard.vue
+++ b/portfolio/components/TravelCard.vue
@@ -14,7 +14,7 @@
         class="pointer-events-none absolute inset-0 z-0 rounded-2xl bg-slate-900/10 opacity-0 transition duration-100 group-hover:opacity-100 group-hover:shadow-[0_0_25px_4px_rgba(255,255,255,0.6)]"
       ></div>
       <div
-        class="absolute left-0 top-0 z-10 flex w-full flex-col bg-slate-900/10 px-3 py-2 backdrop-blur-sm md:px-5 md:py-3"
+        class="absolute left-0 top-0 z-10 flex w-full flex-col bg-slate-900/10 px-2 py-2 backdrop-blur-sm md:px-5 md:py-3"
       >
         <p
           class="flex justify-end space-x-1 text-sm drop-shadow-sm md:text-base"
@@ -27,7 +27,7 @@
         </p>
       </div>
       <div
-        class="absolute bottom-0 left-0 z-10 flex w-full flex-col bg-slate-900/10 px-3 py-2 backdrop-blur-sm md:px-5 md:py-3"
+        class="absolute bottom-0 left-0 z-10 flex w-full flex-col bg-slate-900/10 px-2 py-2 backdrop-blur-sm md:px-5 md:py-3"
       >
         <div class="flex items-center space-x-2">
           <div class="flex w-full items-center justify-between">

--- a/portfolio/components/TravelCardGrid.vue
+++ b/portfolio/components/TravelCardGrid.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <div
-      class="grid grid-cols-3 md:grid-cols-3 md:gap-3 lg:grid-cols-4 xl:grid-cols-6 gap-1 bg-none"
+      class="grid grid-cols-3 gap-1 bg-none md:grid-cols-3 md:gap-3 lg:grid-cols-4 xl:grid-cols-6"
     >
       <TravelCard v-for="card in cards" :key="card.title" v-bind="card" />
       <TravelCardViewAll v-if="displayViewAll" />

--- a/portfolio/components/TravelCardGrid.vue
+++ b/portfolio/components/TravelCardGrid.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <div
-      class="grid grid-cols-2 gap-2 md:grid-cols-3 md:gap-3 lg:grid-cols-4 xl:grid-cols-6"
+      class="grid grid-cols-3 md:grid-cols-3 md:gap-3 lg:grid-cols-4 xl:grid-cols-6 gap-1 bg-none"
     >
       <TravelCard v-for="card in cards" :key="card.title" v-bind="card" />
       <TravelCardViewAll v-if="displayViewAll" />

--- a/portfolio/components/TravelCardViewAll.vue
+++ b/portfolio/components/TravelCardViewAll.vue
@@ -1,7 +1,7 @@
 <template>
   <NuxtLink id="travel-card" to="/travel/">
     <div
-      class="group relative aspect-[4/5] overflow-hidden rounded-2xl border border-slate-50/30 bg-gradient-to-br from-slate-500/70 via-slate-500/30 to-slate-900/50 shadow-lg"
+      class="group relative aspect-[3/4] overflow-hidden rounded-2xl border border-slate-50/30 bg-gradient-to-br from-slate-500/70 via-slate-500/30 to-slate-900/50 shadow-lg"
     >
       <div
         class="pointer-events-none absolute inset-0 z-0 rounded-2xl bg-slate-900/20 opacity-0 transition duration-100 group-hover:opacity-100 group-hover:shadow-[0_0_25px_4px_rgba(255,255,255,0.6)]"

--- a/portfolio/pages/editor.vue
+++ b/portfolio/pages/editor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container mx-auto px-3">
+  <div class="container mx-auto px-2 md:px-3">
     <div>
       <HomeHero />
     </div>

--- a/portfolio/pages/index.vue
+++ b/portfolio/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container mx-auto px-3">
+  <div class="container mx-auto px-2 md:px-3">
     <div>
       <HomeHero />
     </div>

--- a/portfolio/pages/portfolio.vue
+++ b/portfolio/pages/portfolio.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container mx-auto px-3 py-5">
+  <div class="container mx-auto px-2 md:px-3">
     <div>
       <div>
         <h1 class="text-2xl font-semibold text-slate-50">Portfolio</h1>

--- a/portfolio/pages/travel/index.vue
+++ b/portfolio/pages/travel/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container mx-auto px-3 py-5">
+  <div class="container mx-auto px-2 md:px-3">
     <h1
       class="bg-gradient-to-b from-white via-slate-100 to-slate-300 bg-clip-text text-2xl font-semibold text-transparent"
     >

--- a/portfolio/pages/travel/index.vue
+++ b/portfolio/pages/travel/index.vue
@@ -5,14 +5,14 @@
     >
       Travel
     </h1>
-    <h2 class="mt-2 text-lg leading-snug text-slate-200/90">
+    <h2 class="mt-3 text-lg leading-snug text-slate-200/90">
       <span
         class="bg-gradient-to-b from-white to-slate-300 bg-clip-text text-transparent"
       >
         Trips
       </span>
     </h2>
-    <div id="travel-grid-card" class="mt-5">
+    <div id="travel-grid-card" class="mt-3">
       <TravelCardGrid :cards="travelCardGrid" />
     </div>
   </div>

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -97,7 +97,7 @@
               <div
                 v-for="photo in post?.photos"
                 :key="photo.slug"
-                class="relative aspect-[4/5] h-52 shrink-0 overflow-hidden overflow-hidden rounded-2xl border border-slate-200/30 shadow-lg"
+                class="relative aspect-[3/4] h-52 shrink-0 overflow-hidden overflow-hidden rounded-2xl border border-slate-200/30 shadow-lg"
               >
                 <button
                   type="button"

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -1,8 +1,9 @@
 <template>
   <div class="min-h-screen text-slate-50">
-    <div class="mx-auto w-full space-y-4 px-0 py-4 sm:px-4">
+    <div class="mx-auto w-full space-y-4">
+      <div class="px-2 md:px-3">
       <section
-        class="relative mx-auto max-w-2xl overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-[0_12px_40px_rgba(0,0,0,0.35)] backdrop-blur-xl"
+        class="relative mx-auto max-w-xl overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-[0_12px_40px_rgba(0,0,0,0.35)] backdrop-blur-xl mt-3"
       >
         <NuxtImg
           v-if="trip?.coverPhoto"
@@ -16,7 +17,7 @@
           class="absolute inset-0 bg-gradient-to-br from-black/40 via-black/30 to-black/70"
         />
 
-        <div class="relative p-4 sm:p-5">
+        <div class="relative px-5 py-4">
           <div class="flex flex-wrap items-center gap-1.5 text-xs">
             <span
               class="rounded-full border border-white/10 bg-white/10 px-2 py-1 text-white/80 backdrop-blur-xl"
@@ -42,11 +43,13 @@
           </p>
         </div>
       </section>
+      </div>
+      <div class="px-0 md:px-3">
 
-      <section class="mx-auto w-full max-w-xl space-y-4">
+      <section class="mx-auto w-full md:max-w-3xl space-y-4">
         <div
           v-if="!trip?.posts?.length"
-          class="rounded-2xl border border-white/10 bg-white/5 p-4 text-white/70 backdrop-blur-xl"
+          class="rounded-2xl border-t border-b border-white/10 bg-white/5 p-4 text-white/70 backdrop-blur-xl"
         >
           No posts yet.
         </div>
@@ -55,7 +58,7 @@
           v-for="post in trip.posts"
           v-else
           :key="post.slug"
-          class="overflow-hidden border border-white/10 bg-white/5 shadow-none backdrop-blur-xl sm:rounded-2xl sm:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
+          class="overflow-hidden border-t border-b border-white/10 bg-white/5 shadow-none backdrop-blur-xl md:rounded-2xl md:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
         >
           <header class="flex items-center gap-2 p-3">
             <div
@@ -119,12 +122,13 @@
 
           <div
             v-if="post?.description"
-            class="border-t border-white/10 px-3 py-2 text-sm text-white/65"
+            class="border-t border-white/10 px-2 md:px-3 py-2 text-sm text-white/65"
           >
             {{ post.description }}
           </div>
         </article>
       </section>
+      </div>
     </div>
 
     <Teleport to="body">

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -94,7 +94,7 @@
               <div
                 v-for="photo in post?.photos"
                 :key="photo.slug"
-                class="relative aspect-[4/5] w-[28.5%] shrink-0 overflow-hidden rounded-lg sm:w-[26%] md:w-[23.5%] lg:w-[21%]"
+                class="relative aspect-[4/5] h-52 shrink-0 overflow-hidden rounded-lg"
               >
                 <button
                   type="button"
@@ -106,7 +106,7 @@
                     :alt="photo.title"
                     class="h-full w-full object-cover"
                     height="400"
-                    width="400"
+                    width="300"
                   />
                 </button>
               </div>

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -97,7 +97,7 @@
               <div
                 v-for="photo in post?.photos"
                 :key="photo.slug"
-                class="relative aspect-[3/4] h-52 shrink-0 overflow-hidden overflow-hidden rounded-2xl border border-slate-200/30 shadow-lg"
+                class="relative aspect-[3/4] h-52 shrink-0 overflow-hidden overflow-hidden rounded-2xl border border-slate-50/10 shadow-lg"
               >
                 <button
                   type="button"

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -2,132 +2,131 @@
   <div class="min-h-screen text-slate-50">
     <div class="mx-auto w-full space-y-4">
       <div class="px-2 md:px-3">
-      <section
-        class="relative mx-auto max-w-xl overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-[0_12px_40px_rgba(0,0,0,0.35)] backdrop-blur-xl mt-3"
-      >
-        <NuxtImg
-          v-if="trip?.coverPhoto"
-          :src="trip.coverPhoto"
-          :alt="trip?.title"
-          class="absolute inset-0 h-full w-full object-cover opacity-40"
-          height="600"
-          width="1200"
-        />
-        <div
-          class="absolute inset-0 bg-gradient-to-br from-black/40 via-black/30 to-black/70"
-        />
+        <section
+          class="relative mx-auto mt-3 max-w-xl overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-[0_12px_40px_rgba(0,0,0,0.35)] backdrop-blur-xl"
+        >
+          <NuxtImg
+            v-if="trip?.coverPhoto"
+            :src="trip.coverPhoto"
+            :alt="trip?.title"
+            class="absolute inset-0 h-full w-full object-cover opacity-40"
+            height="600"
+            width="1200"
+          />
+          <div
+            class="absolute inset-0 bg-gradient-to-br from-black/40 via-black/30 to-black/70"
+          />
 
-        <div class="relative px-5 py-4">
-          <div class="flex flex-wrap items-center gap-1.5 text-xs">
-            <span
-              class="rounded-full border border-white/10 bg-white/10 px-2 py-1 text-white/80 backdrop-blur-xl"
-            >
-              {{ formatDateRange(trip?.startDate, trip?.endDate) }}
-            </span>
-            <span
-              class="flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-2 py-1 text-white/80 backdrop-blur-xl"
-            >
-              <Twemoji
-                v-for="(emoji, i) in trip?.countries.map(getFlagEmoji)"
-                :key="i"
-                :emoji="emoji"
-              />
-            </span>
+          <div class="relative px-5 py-4">
+            <div class="flex flex-wrap items-center gap-1.5 text-xs">
+              <span
+                class="rounded-full border border-white/10 bg-white/10 px-2 py-1 text-white/80 backdrop-blur-xl"
+              >
+                {{ formatDateRange(trip?.startDate, trip?.endDate) }}
+              </span>
+              <span
+                class="flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-2 py-1 text-white/80 backdrop-blur-xl"
+              >
+                <Twemoji
+                  v-for="(emoji, i) in trip?.countries.map(getFlagEmoji)"
+                  :key="i"
+                  :emoji="emoji"
+                />
+              </span>
+            </div>
+
+            <h1 class="mt-2 text-3xl font-semibold tracking-tight text-white">
+              {{ trip?.title }}
+            </h1>
+            <p class="mt-1.5 max-w-prose text-sm text-white/70">
+              {{ trip?.description }}
+            </p>
           </div>
-
-          <h1 class="mt-2 text-3xl font-semibold tracking-tight text-white">
-            {{ trip?.title }}
-          </h1>
-          <p class="mt-1.5 max-w-prose text-sm text-white/70">
-            {{ trip?.description }}
-          </p>
-        </div>
-      </section>
+        </section>
       </div>
       <div class="px-0 md:px-3">
+        <section class="mx-auto w-full space-y-4 md:max-w-3xl">
+          <div
+            v-if="!trip?.posts?.length"
+            class="rounded-2xl border-b border-t border-white/10 bg-white/5 p-4 text-white/70 backdrop-blur-xl"
+          >
+            No posts yet.
+          </div>
 
-      <section class="mx-auto w-full md:max-w-3xl space-y-4">
-        <div
-          v-if="!trip?.posts?.length"
-          class="rounded-2xl border-t border-b border-white/10 bg-white/5 p-4 text-white/70 backdrop-blur-xl"
-        >
-          No posts yet.
-        </div>
+          <article
+            v-for="post in trip.posts"
+            v-else
+            :key="post.slug"
+            class="overflow-hidden border-b border-t border-white/10 bg-white/5 shadow-none backdrop-blur-xl md:rounded-2xl md:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
+          >
+            <header class="flex items-center gap-2 px-2 py-2 md:px-3 md:py-3">
+              <div
+                class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/10"
+              >
+                <NuxtImg
+                  src="/trips/2025-04-asia/photos/IMG_2292.jpeg"
+                  :alt="post?.title"
+                  class="h-full w-full object-cover"
+                  height="80"
+                  width="80"
+                />
+              </div>
 
-        <article
-          v-for="post in trip.posts"
-          v-else
-          :key="post.slug"
-          class="overflow-hidden border-t border-b border-white/10 bg-white/5 shadow-none backdrop-blur-xl md:rounded-2xl md:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
-        >
-          <header class="flex items-center gap-2 px-2 md:px-3 py-2 md:py-3">
-            <div
-              class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/10"
-            >
-              <NuxtImg
-                src="/trips/2025-04-asia/photos/IMG_2292.jpeg"
-                :alt="post?.title"
-                class="h-full w-full object-cover"
-                height="80"
-                width="80"
+              <div class="min-w-0 flex-1">
+                <p class="truncate text-sm font-semibold text-white">
+                  {{ post?.title }}
+                </p>
+                <p class="truncate text-xs text-white/60">
+                  {{ formatPostDate(post?.datePosted) }}
+                </p>
+              </div>
+
+              <div
+                class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-xs text-white/70"
+              >
+                {{ post?.photos?.length ?? 0 }} photos
+              </div>
+            </header>
+
+            <div class="relative">
+              <div
+                data-carousel="true"
+                class="carousel-scrollbar relative z-0 flex cursor-grab select-none gap-1.5 overflow-x-scroll bg-white/5 px-2 py-2 active:cursor-grabbing md:px-3 md:py-3"
+              >
+                <div
+                  v-for="photo in post?.photos"
+                  :key="photo.slug"
+                  class="relative aspect-[3/4] h-52 shrink-0 overflow-hidden rounded-2xl border border-slate-50/10 shadow-lg"
+                >
+                  <button
+                    type="button"
+                    class="block h-full w-full"
+                    @click="onPhotoClick(photo, $event)"
+                  >
+                    <NuxtImg
+                      :src="photo.photoUrl"
+                      :alt="photo.title"
+                      class="h-full w-full object-cover"
+                      height="400"
+                      width="300"
+                    />
+                  </button>
+                </div>
+              </div>
+
+              <div
+                class="pointer-events-none absolute bottom-3 right-0 top-0 z-10 w-6 bg-gradient-to-l from-slate-950/80 via-slate-950/40 to-transparent transition-opacity"
               />
             </div>
 
-            <div class="min-w-0 flex-1">
-              <p class="truncate text-sm font-semibold text-white">
-                {{ post?.title }}
-              </p>
-              <p class="truncate text-xs text-white/60">
-                {{ formatPostDate(post?.datePosted) }}
-              </p>
-            </div>
-
             <div
-              class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-xs text-white/70"
+              v-if="post?.description"
+              class="border-t border-white/10 px-2 py-2 text-sm text-white/65 md:px-3 md:py-3"
             >
-              {{ post?.photos?.length ?? 0 }} photos
+              {{ post.description }}
             </div>
-          </header>
-
-          <div class="relative">
-            <div
-              data-carousel="true"
-              class="carousel-scrollbar relative z-0 flex cursor-grab select-none gap-1.5 overflow-x-scroll bg-white/5 px-2 md:px-3 py-2 md:py-3 active:cursor-grabbing"
-            >
-              <div
-                v-for="photo in post?.photos"
-                :key="photo.slug"
-                class="relative aspect-[3/4] h-52 shrink-0 overflow-hidden overflow-hidden rounded-2xl border border-slate-50/10 shadow-lg"
-              >
-                <button
-                  type="button"
-                  class="block h-full w-full"
-                  @click="onPhotoClick(photo, $event)"
-                >
-                  <NuxtImg
-                    :src="photo.photoUrl"
-                    :alt="photo.title"
-                    class="h-full w-full object-cover"
-                    height="400"
-                    width="300"
-                  />
-                </button>
-              </div>
-            </div>
-
-            <div
-              class="pointer-events-none absolute bottom-3 right-0 top-0 z-10 w-6 bg-gradient-to-l from-slate-950/80 via-slate-950/40 to-transparent transition-opacity"
-            />
-          </div>
-
-          <div
-            v-if="post?.description"
-            class="border-t border-white/10 px-2 md:px-3 py-2 md:py-3 text-sm text-white/65"
-          >
-            {{ post.description }}
-          </div>
-        </article>
-      </section>
+          </article>
+        </section>
       </div>
     </div>
 

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -60,7 +60,7 @@
           :key="post.slug"
           class="overflow-hidden border-t border-b border-white/10 bg-white/5 shadow-none backdrop-blur-xl md:rounded-2xl md:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
         >
-          <header class="flex items-center gap-2 p-3">
+          <header class="flex items-center gap-2 px-2 md:px-3 py-2 md:py-3">
             <div
               class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/10"
             >
@@ -92,12 +92,12 @@
           <div class="relative">
             <div
               data-carousel="true"
-              class="carousel-scrollbar relative z-0 flex cursor-grab select-none gap-1.5 overflow-x-scroll bg-white/5 px-2 py-2 active:cursor-grabbing"
+              class="carousel-scrollbar relative z-0 flex cursor-grab select-none gap-1.5 overflow-x-scroll bg-white/5 px-2 md:px-3 py-2 md:py-3 active:cursor-grabbing"
             >
               <div
                 v-for="photo in post?.photos"
                 :key="photo.slug"
-                class="relative aspect-[4/5] h-52 shrink-0 overflow-hidden rounded-lg"
+                class="relative aspect-[4/5] h-52 shrink-0 overflow-hidden overflow-hidden rounded-2xl border border-slate-200/30 shadow-lg"
               >
                 <button
                   type="button"
@@ -122,7 +122,7 @@
 
           <div
             v-if="post?.description"
-            class="border-t border-white/10 px-2 md:px-3 py-2 text-sm text-white/65"
+            class="border-t border-white/10 px-2 md:px-3 py-2 md:py-3 text-sm text-white/65"
           >
             {{ post.description }}
           </div>


### PR DESCRIPTION
This pull request:

- Implements a 3-column layout, and adjusts content length and padding to suit
- Migrates image display from 4:5 to 3:4
- Tweaks image carousel to show ~2.5 photos on iPhones 12–17 at 3:4
- Polishes vertical padding and margins
- Polishes border styling
- Tweaks responsiveness, including full-width on mobile

### Three-column layout

<img width="413" height="781" alt="image" src="https://github.com/user-attachments/assets/31e45bb9-707c-402a-b1e7-801c30b1fa91" />

### Image carousel

<img width="392" height="588" alt="image" src="https://github.com/user-attachments/assets/74fb03e5-0485-4c49-8294-2d229bb6daa6" />
