### PR TITLE
feat: horizontal padding optimisation, heading and border polish

### DIFF
--- a/portfolio/components/NavigationBar.vue
+++ b/portfolio/components/NavigationBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="container mx-auto flex px-2 py-5 md:px-3">
+  <nav class="container mx-auto flex px-3 py-5 md:px-5">
     <ul class="flex flex-grow space-x-4">
       <li>
         <NuxtLink to="/" class="flex items-center space-x-3">
@@ -51,7 +51,7 @@
       <li>
         <a
           href="#"
-          class="absolute right-0 z-30 flex-none md:px-3 px-2"
+          class="absolute right-0 z-30 flex-none px-3 md:px-5"
           @click="showMenu = !showMenu"
           ><p
             class="rounded bg-slate-900 bg-opacity-10 px-2 py-2 font-semibold tracking-wide text-slate-200 hover:bg-opacity-30"

--- a/portfolio/components/NavigationBar.vue
+++ b/portfolio/components/NavigationBar.vue
@@ -51,7 +51,7 @@
       <li>
         <a
           href="#"
-          class="absolute right-0 z-30 flex-none px-5 md:px-3"
+          class="absolute right-0 z-30 flex-none md:px-3 px-2"
           @click="showMenu = !showMenu"
           ><p
             class="rounded bg-slate-900 bg-opacity-10 px-2 py-2 font-semibold tracking-wide text-slate-200 hover:bg-opacity-30"

--- a/portfolio/components/TravelCardViewAll.vue
+++ b/portfolio/components/TravelCardViewAll.vue
@@ -1,7 +1,7 @@
 <template>
   <NuxtLink id="travel-card" to="/travel/">
     <div
-      class="group relative aspect-[3/4] overflow-hidden rounded-2xl border border-slate-50/30 bg-gradient-to-br from-slate-500/70 via-slate-500/30 to-slate-900/50 shadow-lg"
+      class="group relative aspect-[3/4] overflow-hidden rounded-2xl border border-slate-50/10 bg-gradient-to-br from-slate-500/70 via-slate-500/30 to-slate-900/50 shadow-lg"
     >
       <div
         class="pointer-events-none absolute inset-0 z-0 rounded-2xl bg-slate-900/20 opacity-0 transition duration-100 group-hover:opacity-100 group-hover:shadow-[0_0_25px_4px_rgba(255,255,255,0.6)]"

--- a/portfolio/pages/index.vue
+++ b/portfolio/pages/index.vue
@@ -1,15 +1,17 @@
 <template>
-  <div class="container mx-auto px-2 md:px-3">
-    <div>
+  <div class="container mx-auto">
+    <div class="px-3 md:px-5">
       <HomeHero />
     </div>
     <div class="container mx-auto mt-8">
-      <h1
-        class="bg-gradient-to-b from-white via-slate-100 to-slate-300 bg-clip-text text-2xl font-semibold text-transparent"
-      >
-        Travel
-      </h1>
-      <div id="travel-grid-card" class="mt-3">
+      <div class="px-3 md:px-5">
+        <h1
+          class="bg-gradient-to-b from-white via-slate-100 to-slate-300 bg-clip-text text-2xl font-semibold text-transparent"
+        >
+          Travel
+        </h1>
+      </div>
+      <div id="travel-grid-card" class="mt-3 px-1 md:px-2">
         <TravelCardGrid :cards="travelCardGrid" :display-view-all="true" />
       </div>
     </div>

--- a/portfolio/pages/portfolio.vue
+++ b/portfolio/pages/portfolio.vue
@@ -1,13 +1,15 @@
 <template>
-  <div class="container mx-auto px-2 md:px-3">
+  <div class="container mx-auto">
     <div>
-      <div>
-        <h1 class="text-2xl font-semibold text-slate-50">Portfolio</h1>
+      <div class="px-3 md:px-5">
+        <div>
+          <h1 class="text-2xl font-semibold text-slate-50">Portfolio</h1>
+        </div>
+        <div class="mt-5">
+          <h1 class="text-xl font-semibold text-slate-100">Experience</h1>
+        </div>
       </div>
-      <div class="mt-5">
-        <h1 class="text-xl font-semibold text-slate-100">Experience</h1>
-      </div>
-      <div class="mb-8 mt-5 grid gap-3 lg:grid-cols-2">
+      <div class="mb-8 mt-5 grid gap-3 px-1 md:px-2 lg:grid-cols-2">
         <div>
           <div
             class="flex items-center overflow-hidden rounded-2xl border border-white/20 bg-white/10 backdrop-blur-lg transition hover:bg-white/20"
@@ -133,7 +135,7 @@
           </div>
         </div>
       </div>
-      <div class="mt-5">
+      <div class="mt-5 px-3 md:px-5">
         <h1 class="text-xl font-semibold text-slate-100">Projects</h1>
       </div>
       <div class="mb-8 mt-5 grid gap-3 lg:grid-cols-2">

--- a/portfolio/pages/portfolio.vue
+++ b/portfolio/pages/portfolio.vue
@@ -2,12 +2,18 @@
   <div class="container mx-auto">
     <div>
       <div class="px-3 md:px-5">
-        <div>
-          <h1 class="text-2xl font-semibold text-slate-50">Portfolio</h1>
-        </div>
-        <div class="mt-5">
-          <h1 class="text-xl font-semibold text-slate-100">Experience</h1>
-        </div>
+        <h1
+          class="bg-gradient-to-b from-white via-slate-100 to-slate-300 bg-clip-text text-2xl font-semibold text-transparent"
+        >
+          Portfolio
+        </h1>
+        <h2 class="mt-3 text-lg leading-snug text-slate-200/90">
+          <span
+            class="bg-gradient-to-b from-white to-slate-300 bg-clip-text text-transparent"
+          >
+            Experience
+          </span>
+        </h2>
       </div>
       <div class="mb-8 mt-5 grid gap-3 px-1 md:px-2 lg:grid-cols-2">
         <div>
@@ -136,7 +142,13 @@
         </div>
       </div>
       <div class="mt-5 px-3 md:px-5">
-        <h1 class="text-xl font-semibold text-slate-100">Projects</h1>
+        <h2 class="mt-3 text-lg leading-snug text-slate-200/90">
+          <span
+            class="bg-gradient-to-b from-white to-slate-300 bg-clip-text text-transparent"
+          >
+            Projects
+          </span>
+        </h2>
       </div>
       <div class="mb-8 mt-5 grid gap-3 lg:grid-cols-2">
         <div>

--- a/portfolio/pages/travel/index.vue
+++ b/portfolio/pages/travel/index.vue
@@ -1,18 +1,20 @@
 <template>
-  <div class="container mx-auto px-2 md:px-3">
-    <h1
-      class="bg-gradient-to-b from-white via-slate-100 to-slate-300 bg-clip-text text-2xl font-semibold text-transparent"
-    >
-      Travel
-    </h1>
-    <h2 class="mt-3 text-lg leading-snug text-slate-200/90">
-      <span
-        class="bg-gradient-to-b from-white to-slate-300 bg-clip-text text-transparent"
+  <div class="container mx-auto">
+    <div class="px-3 md:px-5">
+      <h1
+        class="bg-gradient-to-b from-white via-slate-100 to-slate-300 bg-clip-text text-2xl font-semibold text-transparent"
       >
-        Trips
-      </span>
-    </h2>
-    <div id="travel-grid-card" class="mt-3">
+        Travel
+      </h1>
+      <h2 class="mt-3 text-lg leading-snug text-slate-200/90">
+        <span
+          class="bg-gradient-to-b from-white to-slate-300 bg-clip-text text-transparent"
+        >
+          Trips
+        </span>
+      </h2>
+    </div>
+    <div id="travel-grid-card" class="mt-3 px-1 md:px-2">
       <TravelCardGrid :cards="travelCardGrid" />
     </div>
   </div>

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -1,7 +1,7 @@
 <template>
   <div class="min-h-screen text-slate-50">
     <div class="mx-auto w-full space-y-4">
-      <div class="px-2 md:px-3">
+      <div class="px-3 md:px-5">
         <section
           class="relative mx-auto mt-3 max-w-xl overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-[0_12px_40px_rgba(0,0,0,0.35)] backdrop-blur-xl"
         >


### PR DESCRIPTION
This pull request:
- Optimises horizontal padding by using `px-1` for content, and `px-3` for headings, on mobile
- Fixes "view all" button border brightness
- Makes portfolio page heading styling consistent with home and travel pages

<img width="391" height="756" alt="image" src="https://github.com/user-attachments/assets/0d48617b-db06-4beb-866f-8d52547aec01" />
