### PR TITLE
feat: travel post layout, description expansion, carousel polish, layout tweaks

### DIFF
--- a/portfolio/components/TravelCard.vue
+++ b/portfolio/components/TravelCard.vue
@@ -1,7 +1,7 @@
 <template>
   <NuxtLink id="travel-card" :to="`/travel/trips/${slug}/`">
     <div
-      class="group relative aspect-[3/4] overflow-hidden rounded-2xl border border-slate-50/10 shadow-lg"
+      class="group relative aspect-[3/4] overflow-hidden rounded-2xl border border-slate-50/20 shadow-lg"
     >
       <NuxtImg
         :src="coverPhoto"

--- a/portfolio/components/TravelCard.vue
+++ b/portfolio/components/TravelCard.vue
@@ -17,7 +17,7 @@
         class="absolute left-0 top-0 z-10 flex w-full flex-col bg-slate-900/10 px-2 py-2 backdrop-blur-sm md:px-5 md:py-3"
       >
         <p
-          class="flex justify-end space-x-1 text-sm drop-shadow-sm md:text-base"
+          class="space-x-0.5 text-right text-sm text-slate-50 drop-shadow-sm md:text-base"
         >
           <Twemoji
             v-for="(emoji, i) in countries.map(getFlagEmoji)"

--- a/portfolio/components/TravelCardGrid.vue
+++ b/portfolio/components/TravelCardGrid.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <div
-      class="grid grid-cols-3 gap-1 bg-none md:grid-cols-3 md:gap-3 lg:grid-cols-4 xl:grid-cols-6"
+      class="grid grid-cols-3 gap-[3px] bg-none md:grid-cols-3 md:gap-3 lg:grid-cols-4 xl:grid-cols-6"
     >
       <TravelCard v-for="card in cards" :key="card.title" v-bind="card" />
       <TravelCardViewAll v-if="displayViewAll" />

--- a/portfolio/components/TravelCardViewAll.vue
+++ b/portfolio/components/TravelCardViewAll.vue
@@ -1,7 +1,7 @@
 <template>
   <NuxtLink id="travel-card" to="/travel/">
     <div
-      class="group relative aspect-[3/4] overflow-hidden rounded-2xl border border-slate-50/10 bg-gradient-to-br from-slate-500/70 via-slate-500/30 to-slate-900/50 shadow-lg"
+      class="group relative aspect-[3/4] overflow-hidden rounded-2xl border border-slate-50/20 bg-gradient-to-br from-slate-500/70 via-slate-500/30 to-slate-900/50 shadow-lg"
     >
       <div
         class="pointer-events-none absolute inset-0 z-0 rounded-2xl bg-slate-900/20 opacity-0 transition duration-100 group-hover:opacity-100 group-hover:shadow-[0_0_25px_4px_rgba(255,255,255,0.6)]"

--- a/portfolio/components/TravelPost.vue
+++ b/portfolio/components/TravelPost.vue
@@ -1,8 +1,8 @@
 <template>
   <article
-    class="overflow-hidden border-b border-t border-white/10 bg-white/5 shadow-none backdrop-blur-xl md:rounded-2xl md:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
+    class="overflow-hidden border-b border-t border-white/10 bg-white/5 pb-2 shadow-none backdrop-blur-xl md:rounded-2xl md:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
   >
-    <header class="flex items-center gap-2 px-2 py-2 md:px-3 md:py-3">
+    <header class="flex items-center gap-2 px-3 py-2">
       <div
         class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/10"
       >
@@ -31,7 +31,7 @@
       </div>
     </header>
 
-    <div v-if="post?.description" class="mt-1 px-3 text-sm text-slate-50">
+    <div v-if="post?.description" class="px-3 text-sm text-slate-50">
       <div class="min-w-0 flex-1 text-slate-50/90">
         <p class="whitespace-pre-line text-xs">
           {{ post.description }}
@@ -42,7 +42,7 @@
     <div class="relative">
       <div
         data-carousel="true"
-        class="carousel-scrollbar relative z-0 flex cursor-grab select-none gap-1.5 overflow-x-scroll bg-white/5 px-2 py-2 active:cursor-grabbing md:px-3 md:py-3"
+        class="carousel-scrollbar relative z-0 mt-2 flex cursor-grab select-none gap-1.5 overflow-x-scroll px-3 py-1 active:cursor-grabbing"
       >
         <div
           v-for="photo in post?.photos"

--- a/portfolio/components/TravelPost.vue
+++ b/portfolio/components/TravelPost.vue
@@ -32,28 +32,34 @@
     </header>
 
     <div v-if="post?.description" class="px-3 text-sm text-slate-50">
-      <details
-        class="group flex min-w-0 flex-1 flex-col text-xs leading-4 text-slate-50/90"
-      >
+      <details class="group min-w-0 flex-1 text-xs leading-4 text-slate-50/90">
         <summary
-          class="order-last block cursor-pointer list-none [&::-webkit-details-marker]:hidden [&::marker]:content-['']"
+          class="mt-1 block cursor-pointer list-none [&::-webkit-details-marker]:hidden [&::marker]:content-['']"
         >
-          <div class="group-open:hidden">
-            <p class="max-h-8 overflow-hidden whitespace-pre-line pr-1">
+          <span class="relative block group-open:hidden">
+            <p class="line-clamp-2">
               {{ post.description }}
             </p>
-          </div>
-          <div
-            class="mt-1 font-medium text-slate-200/80 transition hover:text-slate-50"
-          >
-            <span class="group-open:hidden">See more</span>
-            <span class="hidden group-open:inline">See less</span>
-          </div>
-        </summary>
+            <p
+              class="pointer-events-none mt-1 text-right font-medium text-slate-200/80"
+            >
+              See more
+            </p>
+          </span>
 
-        <p class="hidden whitespace-pre-line pr-1 group-open:block">
-          {{ post.description }}
-        </p>
+          <span class="hidden whitespace-pre-line pr-1 group-open:inline">
+            {{ post.description }}
+          </span>
+          <span
+            class="hidden font-medium text-slate-200/80 transition hover:text-slate-50 group-open:inline"
+          >
+            <p
+              class="pointer-events-none mt-1 text-right font-medium text-slate-200/80"
+            >
+              See less
+            </p>
+          </span>
+        </summary>
       </details>
     </div>
 

--- a/portfolio/components/TravelPost.vue
+++ b/portfolio/components/TravelPost.vue
@@ -31,6 +31,14 @@
       </div>
     </header>
 
+    <div v-if="post?.description" class="mt-1 px-3 text-sm text-slate-50">
+      <div class="min-w-0 flex-1 text-slate-50/90">
+        <p class="whitespace-pre-line text-xs">
+          {{ post.description }}
+        </p>
+      </div>
+    </div>
+
     <div class="relative">
       <div
         data-carousel="true"
@@ -60,13 +68,6 @@
       <div
         class="pointer-events-none absolute bottom-3 right-0 top-0 z-10 w-6 bg-gradient-to-l from-slate-950/80 via-slate-950/40 to-transparent transition-opacity"
       />
-    </div>
-
-    <div
-      v-if="post?.description"
-      class="border-t border-white/10 px-2 py-2 text-sm text-white/65 md:px-3 md:py-3"
-    >
-      {{ post.description }}
     </div>
   </article>
 </template>

--- a/portfolio/components/TravelPost.vue
+++ b/portfolio/components/TravelPost.vue
@@ -1,0 +1,117 @@
+<template>
+  <article
+    class="overflow-hidden border-b border-t border-white/10 bg-white/5 shadow-none backdrop-blur-xl md:rounded-2xl md:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
+  >
+    <header class="flex items-center gap-2 px-2 py-2 md:px-3 md:py-3">
+      <div
+        class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/10"
+      >
+        <NuxtImg
+          src="/trips/2025-04-asia/photos/IMG_2292.jpeg"
+          :alt="post?.title"
+          class="h-full w-full object-cover"
+          height="80"
+          width="80"
+        />
+      </div>
+
+      <div class="min-w-0 flex-1">
+        <p class="truncate text-sm font-semibold text-white">
+          {{ post?.title }}
+        </p>
+        <p class="truncate text-xs text-white/60">
+          {{ formatPostDate(post?.datePosted) }}
+        </p>
+      </div>
+
+      <div
+        class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-xs text-white/70"
+      >
+        {{ post?.photos?.length ?? 0 }} photos
+      </div>
+    </header>
+
+    <div class="relative">
+      <div
+        data-carousel="true"
+        class="carousel-scrollbar relative z-0 flex cursor-grab select-none gap-1.5 overflow-x-scroll bg-white/5 px-2 py-2 active:cursor-grabbing md:px-3 md:py-3"
+      >
+        <div
+          v-for="photo in post?.photos"
+          :key="photo.slug"
+          class="relative aspect-[3/4] h-52 shrink-0 overflow-hidden rounded-2xl border border-slate-50/10 shadow-lg"
+        >
+          <button
+            type="button"
+            class="block h-full w-full"
+            @click="emit('photo-click', photo)"
+          >
+            <NuxtImg
+              :src="photo.photoUrl"
+              :alt="photo.title"
+              class="h-full w-full object-cover"
+              height="800"
+              width="600"
+            />
+          </button>
+        </div>
+      </div>
+
+      <div
+        class="pointer-events-none absolute bottom-3 right-0 top-0 z-10 w-6 bg-gradient-to-l from-slate-950/80 via-slate-950/40 to-transparent transition-opacity"
+      />
+    </div>
+
+    <div
+      v-if="post?.description"
+      class="border-t border-white/10 px-2 py-2 text-sm text-white/65 md:px-3 md:py-3"
+    >
+      {{ post.description }}
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+type TripPhoto = {
+  slug: string;
+  photoUrl: string;
+  title?: string;
+};
+
+type TripPost = {
+  title?: string;
+  datePosted?: string;
+  description?: string;
+  photos?: TripPhoto[];
+};
+
+defineProps<{
+  post: TripPost;
+  formatPostDate: (date: string | undefined) => string;
+}>();
+
+const emit = defineEmits<{
+  "photo-click": [photo: TripPhoto];
+}>();
+</script>
+
+<style scoped>
+.carousel-scrollbar {
+  scrollbar-color: #334155 #0f172a;
+  scrollbar-width: thin;
+}
+
+.carousel-scrollbar::-webkit-scrollbar {
+  height: 8px;
+}
+
+.carousel-scrollbar::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 999px;
+}
+
+.carousel-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(51, 65, 85, 0.9);
+  border-radius: 999px;
+}
+</style>

--- a/portfolio/components/TravelPost.vue
+++ b/portfolio/components/TravelPost.vue
@@ -32,11 +32,29 @@
     </header>
 
     <div v-if="post?.description" class="px-3 text-sm text-slate-50">
-      <div class="min-w-0 flex-1 text-slate-50/90">
-        <p class="whitespace-pre-line text-xs">
+      <details
+        class="group flex min-w-0 flex-1 flex-col text-xs leading-4 text-slate-50/90"
+      >
+        <summary
+          class="order-last block cursor-pointer list-none [&::-webkit-details-marker]:hidden [&::marker]:content-['']"
+        >
+          <div class="group-open:hidden">
+            <p class="max-h-8 overflow-hidden whitespace-pre-line pr-1">
+              {{ post.description }}
+            </p>
+          </div>
+          <div
+            class="mt-1 font-medium text-slate-200/80 transition hover:text-slate-50"
+          >
+            <span class="group-open:hidden">See more</span>
+            <span class="hidden group-open:inline">See less</span>
+          </div>
+        </summary>
+
+        <p class="hidden whitespace-pre-line pr-1 group-open:block">
           {{ post.description }}
         </p>
-      </div>
+      </details>
     </div>
 
     <div class="relative">

--- a/portfolio/components/TravelPost.vue
+++ b/portfolio/components/TravelPost.vue
@@ -64,10 +64,6 @@
           </button>
         </div>
       </div>
-
-      <div
-        class="pointer-events-none absolute bottom-3 right-0 top-0 z-10 w-6 bg-gradient-to-l from-slate-950/80 via-slate-950/40 to-transparent transition-opacity"
-      />
     </div>
   </article>
 </template>

--- a/portfolio/components/TravelPost.vue
+++ b/portfolio/components/TravelPost.vue
@@ -39,7 +39,7 @@
         <div
           v-for="photo in post?.photos"
           :key="photo.slug"
-          class="relative aspect-[3/4] h-52 shrink-0 overflow-hidden rounded-2xl border border-slate-50/10 shadow-lg"
+          class="relative aspect-[3/4] h-48 shrink-0 overflow-hidden rounded-2xl border border-slate-50/10 shadow-lg"
         >
           <button
             type="button"

--- a/portfolio/content/trips/2024-11-svalbard/index.json
+++ b/portfolio/content/trips/2024-11-svalbard/index.json
@@ -14,30 +14,23 @@
   "posts": [
     {
       "slug": "po_019b6fc4-0c03-75f2-9ac8-cb57409f8972",
-      "title": "Svalbard",
-      "description": "A trip to Svalbard.",
+      "title": "78° North",
+      "description": "At 78° north, there is no sunrise. There isn’t even twilight. Every hour is the same, save for a little blue time at noon.\n\nThe city and its community are beautiful, with everybody keeping each other sane through the polar night. Its famous restaurants boast unique culinary experiences such as reindeer, seal, and whale.",
       "datePosted": "2024-12-06",
       "photos": [
-        {
-          "slug": "img-0562",
-          "title": "IMG_0562",
-          "description": "",
-          "dateTaken": "2024-12-01T11:40:00",
-          "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0562.jpeg"
-        },
-        {
-          "slug": "img-0615",
-          "title": "IMG_0615",
-          "description": "",
-          "dateTaken": "2024-12-01T17:53:00",
-          "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0615.jpeg"
-        },
         {
           "slug": "img-0718",
           "title": "IMG_0718",
           "description": "",
           "dateTaken": "2024-12-03T12:23:00",
           "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0718.jpeg"
+        },
+        {
+          "slug": "img-0562",
+          "title": "IMG_0562",
+          "description": "",
+          "dateTaken": "2024-12-01T11:40:00",
+          "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0562.jpeg"
         },
         {
           "slug": "img-0727",
@@ -66,6 +59,28 @@
           "description": "",
           "dateTaken": "2024-12-04T11:25:00",
           "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0759.jpeg"
+        },
+        {
+          "slug": "img-0943",
+          "title": "IMG_0943",
+          "description": "",
+          "dateTaken": "2024-12-06T14:12:00",
+          "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0943.jpeg"
+        }
+      ]
+    },
+    {
+      "slug": "po_019b6fc4-0c03-75f2-9ac8-cb57409f8972",
+      "title": "Ice Cave Overnight",
+      "description": "Longyearbyen is full of cosy restaurants and hotels, so hiking out for the night was an exercise in seeing how we take heat for granted.\n\nThe cold is merciless. I expected to feel it, but I didn’t anticipate my field meal turning to slush instead of curry, nor my Invisalign to be frozen as I put it back in.",
+      "datePosted": "2024-12-05",
+      "photos": [
+        {
+          "slug": "img-0899",
+          "title": "IMG_0899",
+          "description": "",
+          "dateTaken": "2024-12-05T11:03:00",
+          "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0899.jpeg"
         },
         {
           "slug": "img-0838",
@@ -108,20 +123,6 @@
           "description": "",
           "dateTaken": "2024-12-05T11:01:00",
           "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0894.jpeg"
-        },
-        {
-          "slug": "img-0899",
-          "title": "IMG_0899",
-          "description": "",
-          "dateTaken": "2024-12-05T11:03:00",
-          "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0899.jpeg"
-        },
-        {
-          "slug": "img-0943",
-          "title": "IMG_0943",
-          "description": "",
-          "dateTaken": "2024-12-06T14:12:00",
-          "photoUrl": "/trips/2024-11-svalbard/photos/IMG_0943.jpeg"
         }
       ]
     }

--- a/portfolio/pages/index.vue
+++ b/portfolio/pages/index.vue
@@ -10,6 +10,13 @@
         >
           Travel
         </h1>
+        <h2 class="mt-3 text-lg leading-snug text-slate-200/90">
+          <span
+            class="bg-gradient-to-b from-white to-slate-300 bg-clip-text text-transparent"
+          >
+            Highlights
+          </span>
+        </h2>
       </div>
       <div id="travel-grid-card" class="mt-3 px-1 md:px-2">
         <TravelCardGrid :cards="travelCardGrid" :display-view-all="true" />

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -53,79 +53,14 @@
             No posts yet.
           </div>
 
-          <article
+          <TravelPost
             v-for="post in trip.posts"
             v-else
             :key="post.slug"
-            class="overflow-hidden border-b border-t border-white/10 bg-white/5 shadow-none backdrop-blur-xl md:rounded-2xl md:shadow-[0_10px_30px_rgba(0,0,0,0.35)]"
-          >
-            <header class="flex items-center gap-2 px-2 py-2 md:px-3 md:py-3">
-              <div
-                class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/10"
-              >
-                <NuxtImg
-                  src="/trips/2025-04-asia/photos/IMG_2292.jpeg"
-                  :alt="post?.title"
-                  class="h-full w-full object-cover"
-                  height="80"
-                  width="80"
-                />
-              </div>
-
-              <div class="min-w-0 flex-1">
-                <p class="truncate text-sm font-semibold text-white">
-                  {{ post?.title }}
-                </p>
-                <p class="truncate text-xs text-white/60">
-                  {{ formatPostDate(post?.datePosted) }}
-                </p>
-              </div>
-
-              <div
-                class="rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-xs text-white/70"
-              >
-                {{ post?.photos?.length ?? 0 }} photos
-              </div>
-            </header>
-
-            <div class="relative">
-              <div
-                data-carousel="true"
-                class="carousel-scrollbar relative z-0 flex cursor-grab select-none gap-1.5 overflow-x-scroll bg-white/5 px-2 py-2 active:cursor-grabbing md:px-3 md:py-3"
-              >
-                <div
-                  v-for="photo in post?.photos"
-                  :key="photo.slug"
-                  class="relative aspect-[3/4] h-52 shrink-0 overflow-hidden rounded-2xl border border-slate-50/10 shadow-lg"
-                >
-                  <button
-                    type="button"
-                    class="block h-full w-full"
-                    @click="onPhotoClick(photo, $event)"
-                  >
-                    <NuxtImg
-                      :src="photo.photoUrl"
-                      :alt="photo.title"
-                      class="h-full w-full object-cover"
-                      height="800"
-                      width="600"
-                    />
-                  </button>
-                </div>
-              </div>
-
-              <div
-                class="pointer-events-none absolute bottom-3 right-0 top-0 z-10 w-6 bg-gradient-to-l from-slate-950/80 via-slate-950/40 to-transparent transition-opacity"
-              />
-            </div>
-
-            <div
-              v-if="post?.description"
-              class="border-t border-white/10 px-2 py-2 text-sm text-white/65 md:px-3 md:py-3"
-            >
-              {{ post.description }}
-            </div>
-          </article>
+            :post="post"
+            :format-post-date="formatPostDate"
+            @photo-click="onPhotoClick"
+          />
         </section>
       </div>
     </div>
@@ -287,24 +222,3 @@ onBeforeUnmount(() => {
   window.removeEventListener("keydown", onKeyDown);
 });
 </script>
-
-<style scoped>
-.carousel-scrollbar {
-  scrollbar-color: #334155 #0f172a;
-  scrollbar-width: thin;
-}
-
-.carousel-scrollbar::-webkit-scrollbar {
-  height: 8px;
-}
-
-.carousel-scrollbar::-webkit-scrollbar-track {
-  background: rgba(15, 23, 42, 0.75);
-  border-radius: 999px;
-}
-
-.carousel-scrollbar::-webkit-scrollbar-thumb {
-  background: rgba(51, 65, 85, 0.9);
-  border-radius: 999px;
-}
-</style>

--- a/portfolio/pages/travel/trips/[slug].vue
+++ b/portfolio/pages/travel/trips/[slug].vue
@@ -45,7 +45,7 @@
         </section>
       </div>
       <div class="px-0 md:px-3">
-        <section class="mx-auto w-full space-y-4 md:max-w-3xl">
+        <section class="mx-auto w-full space-y-4 md:max-w-xl">
           <div
             v-if="!trip?.posts?.length"
             class="rounded-2xl border-b border-t border-white/10 bg-white/5 p-4 text-white/70 backdrop-blur-xl"


### PR DESCRIPTION
This pull request:
- Moves travel post description above carousel
- Adds "see more" description expansion
- Removes background from carousel
- Removes right fade from carousel
- Increases horizontal padding on travel post, and makes photos slightly smaller
- Sets max width of posts in travel page
- Updates Svalbard content to demo the changes